### PR TITLE
Gpt integration

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -2,3 +2,7 @@ DATABASE_URL="postgresql://postgres@localhost:5432/meal_recommender?schema=publi
 
 TEST_DATABASE_SCHEMA="test"
 TEST_DATABASE_URL="postgresql://postgres@localhost:5432/meal_recommender?schema=${TEST_DATABASE_SCHEMA}"
+
+OPENAI_API_KEY="some-key"
+
+API_ACCESS_TOKEN="dev-token"

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^3.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^9.0.0",
@@ -27,8 +28,8 @@
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "5.1.1",
+    "axios": "^1.4.0",
     "bcrypt": "^5.1.0",
-    "openai": "^3.3.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/api/package.json
+++ b/api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "5.1.1",
     "bcrypt": "^5.1.0",
+    "openai": "^3.3.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/api/prisma/migrations/20230815125433_request_response_cache/migration.sql
+++ b/api/prisma/migrations/20230815125433_request_response_cache/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "request_cache" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "url" TEXT NOT NULL,
+    "method" TEXT NOT NULL,
+    "headers" JSONB,
+    "body" JSONB,
+
+    CONSTRAINT "request_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "response_cache" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "status_code" INTEGER NOT NULL,
+    "headers" JSONB,
+    "body" JSONB,
+
+    CONSTRAINT "response_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "request_response_cache" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "requestId" INTEGER NOT NULL,
+    "responseId" INTEGER NOT NULL,
+
+    CONSTRAINT "request_response_cache_pkey" PRIMARY KEY ("id")
+);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -58,3 +58,36 @@ model UserRecipe {
 
   @@map("user_recipes")
 }
+
+model RequestCache {
+  id              Int             @id @default(autoincrement())
+  createdAt       DateTime        @default(now())                  @map("created_at")
+  updatedAt       DateTime        @updatedAt                       @map("updated_at")
+  url             String
+  method          String
+  headers         Json?
+  body            Json?
+
+  @@map("request_cache")
+}
+
+model ResponseCache {
+  id              Int             @id @default(autoincrement())
+  createdAt       DateTime        @default(now())                  @map("created_at")
+  updatedAt       DateTime        @updatedAt                       @map("updated_at")
+  statusCode      Int             @map("status_code")
+  headers         Json?
+  body            Json?
+
+  @@map("response_cache")
+}
+
+model RequestResponseCache {
+  id              Int             @id @default(autoincrement())
+  createdAt       DateTime        @default(now())                  @map("created_at")
+  updatedAt       DateTime        @updatedAt                       @map("updated_at")
+  requestId       Int
+  responseId      Int
+
+  @@map("request_response_cache")
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -4,9 +4,15 @@ import { AppService } from './app.service';
 import { UserModule } from './modules/user/user.module';
 import { RecipeModule } from './modules/recipe/recipe.module';
 import { ConfigModule } from '@nestjs/config';
+import { RecommenderModule } from './modules/recommender/recommender.module';
 
 @Module({
-  imports: [UserModule, RecipeModule, ConfigModule.forRoot()],
+  imports: [
+    UserModule,
+    RecipeModule,
+    ConfigModule.forRoot(),
+    RecommenderModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/api/src/modules/auth/guards/api.guard.ts
+++ b/api/src/modules/auth/guards/api.guard.ts
@@ -1,0 +1,34 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class APIGuard implements CanActivate {
+  private readonly apiKeys: string[];
+
+  constructor(private configService: ConfigService) {
+    this.apiKeys = this.configService.get<string[]>('API_ACCESS_TOKENS');
+  }
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    return true;
+
+    try {
+      const req = context.switchToHttp().getRequest();
+
+      const apiKeyHeader = req.headers['api-key'];
+
+      if (this.apiKeys.includes(apiKeyHeader)) {
+        return true;
+      }
+
+      throw new Error('Invalid API key');
+    } catch (error) {
+      console.error({
+        msg: `Unable to authenticate request`,
+        err: error,
+      });
+
+      return false;
+    }
+  }
+}

--- a/api/src/modules/auth/guards/api.guard.ts
+++ b/api/src/modules/auth/guards/api.guard.ts
@@ -10,8 +10,6 @@ export class APIGuard implements CanActivate {
   }
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {
-    return true;
-
     try {
       const req = context.switchToHttp().getRequest();
 

--- a/api/src/modules/recommender/controllers/openai-test-controller.controller.ts
+++ b/api/src/modules/recommender/controllers/openai-test-controller.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { APIGuard } from 'src/modules/auth/guards/api.guard';
+import { OpenaiService } from '../services/openai.service';
+
+@Controller('/internal/chat')
+@UseGuards(APIGuard)
+export class OpenaiTestControllerController {
+  constructor(private readonly openaiService: OpenaiService) {}
+
+  @Get('/test')
+  public async testChat(): Promise<string> {
+    return this.openaiService.testChat();
+  }
+}

--- a/api/src/modules/recommender/recommender.module.ts
+++ b/api/src/modules/recommender/recommender.module.ts
@@ -3,9 +3,10 @@ import { OpenaiService } from './services/openai.service';
 import { OpenaiTestControllerController } from './controllers/openai-test-controller.controller';
 import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from '@nestjs/axios';
+import { UtilsModule } from '../utils/utils.module';
 
 @Module({
-  imports: [ConfigModule, HttpModule],
+  imports: [ConfigModule, HttpModule, UtilsModule],
   controllers: [OpenaiTestControllerController],
   providers: [OpenaiService],
 })

--- a/api/src/modules/recommender/recommender.module.ts
+++ b/api/src/modules/recommender/recommender.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { OpenaiService } from './services/openai.service';
 import { OpenaiTestControllerController } from './controllers/openai-test-controller.controller';
 import { ConfigModule } from '@nestjs/config';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, HttpModule],
   controllers: [OpenaiTestControllerController],
   providers: [OpenaiService],
 })

--- a/api/src/modules/recommender/recommender.module.ts
+++ b/api/src/modules/recommender/recommender.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OpenaiService } from './services/openai.service';
+import { OpenaiTestControllerController } from './controllers/openai-test-controller.controller';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [OpenaiTestControllerController],
+  providers: [OpenaiService],
+})
+export class RecommenderModule {}

--- a/api/src/modules/recommender/services/openai.service.ts
+++ b/api/src/modules/recommender/services/openai.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
+import { RequestCacheService } from '../../utils/services/request-cache.service';
 
 @Injectable()
 export class OpenaiService {
@@ -9,6 +10,7 @@ export class OpenaiService {
   constructor(
     private readonly configService: ConfigService,
     private readonly httpService: HttpService,
+    private readonly requestCacheService: RequestCacheService,
   ) {
     this.apiKey = this.configService.get<string>('OPENAI_API_KEY');
   }
@@ -30,6 +32,8 @@ export class OpenaiService {
         },
       )
       .toPromise();
+
+    await this.requestCacheService.cacheAxiosRequestResponse(response);
 
     return response.data;
   }

--- a/api/src/modules/recommender/services/openai.service.ts
+++ b/api/src/modules/recommender/services/openai.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Configuration, OpenAIApi } from 'openai';
+
+@Injectable()
+export class OpenaiService {
+  private readonly openaiClient: OpenAIApi;
+
+  constructor(private readonly configService: ConfigService) {
+    const configuration = new Configuration({
+      apiKey: this.configService.get<string>('OPENAI_API_KEY'),
+    });
+    this.openaiClient = new OpenAIApi(configuration);
+  }
+
+  public async testChat(): Promise<string> {
+    const chatCompletion = await this.openaiClient.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello world' }],
+    });
+
+    const message = chatCompletion.data.choices[0].message.content;
+
+    return message;
+  }
+}

--- a/api/src/modules/recommender/services/openai.service.ts
+++ b/api/src/modules/recommender/services/openai.service.ts
@@ -1,26 +1,36 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Configuration, OpenAIApi } from 'openai';
+import { HttpService } from '@nestjs/axios';
 
 @Injectable()
 export class OpenaiService {
-  private readonly openaiClient: OpenAIApi;
+  private readonly apiKey: string;
 
-  constructor(private readonly configService: ConfigService) {
-    const configuration = new Configuration({
-      apiKey: this.configService.get<string>('OPENAI_API_KEY'),
-    });
-    this.openaiClient = new OpenAIApi(configuration);
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly httpService: HttpService,
+  ) {
+    this.apiKey = this.configService.get<string>('OPENAI_API_KEY');
   }
 
   public async testChat(): Promise<string> {
-    const chatCompletion = await this.openaiClient.createChatCompletion({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: 'Hello world' }],
-    });
+    const response = await this.httpService
+      .post(
+        'https://api.openai.com/v1/chat/completions',
+        {
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: 'Say this is a test!' }],
+          temperature: 0.7,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+        },
+      )
+      .toPromise();
 
-    const message = chatCompletion.data.choices[0].message.content;
-
-    return message;
+    return response.data;
   }
 }

--- a/api/src/modules/utils/services/request-cache.service.ts
+++ b/api/src/modules/utils/services/request-cache.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../db/services/prisma.service';
+import { AxiosResponse } from 'axios';
+
+type RequestInput = {
+  url: string;
+  method: string;
+  body?: object;
+  headers?: object;
+};
+
+type ResponseInput = {
+  status: number;
+  body?: object;
+  headers?: object;
+};
+
+type RequestCache = {
+  id: number;
+  url: string;
+  method: string;
+  body?: object;
+  headers?: object;
+};
+
+type ResponseCache = {
+  id: number;
+  status: number;
+  body?: object;
+  headers?: object;
+};
+
+@Injectable()
+export class RequestCacheService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  public async cacheAxiosRequestResponse(
+    axiosResponse: AxiosResponse,
+  ): Promise<void> {
+    // If this request contains an Authorization header, change the value to 'REDACTED'
+    const requestHeaders = axiosResponse.config.headers;
+    if (axiosResponse.config.headers.Authorization) {
+      requestHeaders.Authorization = 'REDACTED';
+    }
+
+    const requestInput: RequestInput = {
+      url: axiosResponse.config.url,
+      method: axiosResponse.config.method,
+      body: axiosResponse.config.data
+        ? JSON.parse(axiosResponse.config.data)
+        : undefined,
+      headers: requestHeaders,
+    };
+
+    const requestCache = await this.cacheRequest(requestInput);
+
+    const responseInput: ResponseInput = {
+      status: axiosResponse.status,
+      body: axiosResponse.data,
+      headers: axiosResponse.headers,
+    };
+
+    const responseCache = await this.cacheResponse(responseInput);
+
+    await this.associateRequestAndResponse({
+      requestId: requestCache.id,
+      responseId: responseCache.id,
+    });
+  }
+
+  public async cacheRequest(requestInput: RequestInput): Promise<RequestCache> {
+    const saved = await this.prismaService.requestCache.create({
+      data: {
+        url: requestInput.url,
+        method: requestInput.method,
+        body: requestInput.body,
+        headers: requestInput.headers,
+      },
+    });
+
+    return {
+      id: saved.id,
+      ...requestInput,
+    };
+  }
+
+  private async cacheResponse(
+    responseInput: ResponseInput,
+  ): Promise<ResponseCache> {
+    const saved = await this.prismaService.responseCache.create({
+      data: {
+        statusCode: responseInput.status,
+        body: responseInput.body,
+        headers: responseInput.headers,
+      },
+    });
+
+    return {
+      id: saved.id,
+      ...responseInput,
+    };
+  }
+
+  private async associateRequestAndResponse(input: {
+    requestId: number;
+    responseId: number;
+  }): Promise<void> {
+    await this.prismaService.requestResponseCache.create({
+      data: {
+        requestId: input.requestId,
+        responseId: input.responseId,
+      },
+    });
+  }
+}

--- a/api/src/modules/utils/utils.module.ts
+++ b/api/src/modules/utils/utils.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RequestCacheService } from './services/request-cache.service';
+import { DbModule } from '../db/db.module';
+
+@Module({
+  imports: [DbModule],
+  providers: [RequestCacheService],
+  exports: [RequestCacheService],
+})
+export class UtilsModule {}

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1331,6 +1331,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-jest@^29.6.2:
   version "29.6.2"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.6.2.tgz#cada0a59e07f5acaeb11cbae7e3ba92aec9c1126"
@@ -2183,6 +2190,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.14.8:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 fork-ts-checker-webpack-plugin@8.0.0:
   version "8.0.0"
@@ -3472,6 +3484,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+openai@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-3.3.0.tgz#a6408016ad0945738e1febf43f2fccca83a3f532"
+  integrity sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==
+  dependencies:
+    axios "^0.26.0"
+    form-data "^4.0.0"
 
 ora@5.4.1, ora@^5.4.1:
   version "5.4.1"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -619,6 +619,11 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@nestjs/axios@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-3.0.0.tgz#a2e70b118e3058f3d4b9c3deacd496ec4e3ee69e"
+  integrity sha512-ULdH03jDWkS5dy9X69XbUVbhC+0pVnrRcj7bIK/ytTZ76w7CgvTZDJqsIyisg3kNOiljRW/4NIjSf3j6YGvl+g==
+
 "@nestjs/cli@^9.0.0":
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-9.5.0.tgz#ddf1b0e21b5507c151e0cd1a4cfcf6c55df7cb2e"
@@ -1331,12 +1336,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
   dependencies:
-    follow-redirects "^1.14.8"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.6.2:
   version "29.6.2"
@@ -2191,7 +2198,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-follow-redirects@^1.14.8:
+follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -3485,14 +3492,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-openai@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-3.3.0.tgz#a6408016ad0945738e1febf43f2fccca83a3f532"
-  integrity sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==
-  dependencies:
-    axios "^0.26.0"
-    form-data "^4.0.0"
-
 ora@5.4.1, ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
@@ -3702,6 +3701,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR brings in a few pieces of functionality:
- Sample integration into OpenAI, the request is basically a hello world. Run by hitting endpoint:

`GET internal/chat/test`
```JSON
{
    "id": "chatcmpl-7ntcJPzoCDXcmgXbITNezckN3Aowr",
    "object": "chat.completion",
    "created": 1692126219,
    "model": "gpt-3.5-turbo-0613",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "This is a test!"
            },
            "finish_reason": "stop"
        }
    ],
    "usage": {
        "prompt_tokens": 13,
        "completion_tokens": 5,
        "total_tokens": 18
    }
}
```

- Caches requests and response made via `request-cache.service`. This is to be used if we need to re-import data that comes from OpenAI to fit into our models
- Introduces basic auth guard to controller endpoint