### PR TITLE
#13 associate user to jwt

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -6,3 +6,6 @@ TEST_DATABASE_URL="postgresql://postgres@localhost:5432/meal_recommender?schema=
 OPENAI_API_KEY="some-key"
 
 API_ACCESS_TOKEN="dev-token"
+
+JWT_SECRET="jwt-secret"
+JWT_EXPIRES_IN="5min"

--- a/api/src/modules/auth/auth.module.ts
+++ b/api/src/modules/auth/auth.module.ts
@@ -2,20 +2,24 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './services/auth.service';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
-
-// TODO: Env var this
-export const jwtSecret = 'zjP9h6ZI5LoSKCRj';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     PassportModule,
-    JwtModule.register({
-      secret: jwtSecret,
-      // TODO: Env var this
-      signOptions: { expiresIn: '5m' },
+    ConfigModule.forRoot(),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN'),
+        },
+      }),
     }),
   ],
   providers: [AuthService],
-  exports: [AuthService],
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/api/src/modules/auth/guards/user.guard.ts
+++ b/api/src/modules/auth/guards/user.guard.ts
@@ -1,0 +1,49 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from 'nestjs-pino';
+
+@Injectable()
+export class UserGuard implements CanActivate {
+  private readonly jwtSecret: string;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly logger: Logger,
+  ) {
+    this.jwtSecret = this.configService.get<string>('JWT_SECRET');
+  }
+
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+    try {
+      const payload = await this.jwtService.verifyAsync(token, {
+        secret: this.jwtSecret,
+      });
+
+      request['user'] = payload;
+    } catch (error) {
+      this.logger.error(error.message);
+
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+
+  private extractTokenFromHeader(request: Request): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/api/src/modules/recipe/services/recipe.service.ts
+++ b/api/src/modules/recipe/services/recipe.service.ts
@@ -44,7 +44,8 @@ export class RecipeService {
               ingredientId: ingredient.id,
               recipeId: savedRecipe.id,
               quantity: recipe.recipeIngredients[index].quantity,
-              unit: recipe.recipeIngredients[index].unit,
+              // This is defaulting to 'count' because sometimes the unit is undefined
+              unit: recipe.recipeIngredients[index].unit || 'count',
             },
           }),
         ),

--- a/api/src/modules/recommender/controllers/recommender.controller.ts
+++ b/api/src/modules/recommender/controllers/recommender.controller.ts
@@ -2,18 +2,37 @@ import { Get, Controller, UseGuards, Body } from '@nestjs/common';
 import { RecommenderService } from '../services/recommender.service';
 import { APIGuard } from '../../auth/guards/api.guard';
 import { Logger } from 'nestjs-pino';
+import { UserGuard } from '../../auth/guards/user.guard';
 
 @Controller('recommender')
-@UseGuards(APIGuard)
 export class RecommenderController {
   constructor(
     private readonly recommenderService: RecommenderService,
     private readonly logger: Logger,
   ) {}
 
+  @UseGuards(APIGuard)
   @Get('/generate-recipe')
-  public async test(@Body() input: { recipeName: string }): Promise<string> {
+  public async generateRecipe(
+    @Body() input: { recipeName: string },
+  ): Promise<string> {
     this.logger.log('Generating recipe', {
+      recipeName: input.recipeName,
+    });
+
+    const response = await this.recommenderService.requestRecipe({
+      recipeName: input.recipeName,
+    });
+
+    return response as unknown as string;
+  }
+
+  @UseGuards(UserGuard)
+  @Get('/generate-user-recipe')
+  public async generateUserRecipe(
+    @Body() input: { recipeName: string },
+  ): Promise<string> {
+    this.logger.log('Generating user recipe', {
       recipeName: input.recipeName,
     });
 

--- a/api/src/modules/recommender/recommender.module.ts
+++ b/api/src/modules/recommender/recommender.module.ts
@@ -7,9 +7,20 @@ import { UtilsModule } from '../utils/utils.module';
 import { RecommenderController } from './controllers/recommender.controller';
 import { RecommenderService } from './services/recommender.service';
 import { RecipeModule } from '../recipe/recipe.module';
+import { AuthModule } from '../auth/auth.module';
+import { UserModule } from '../user/user.module';
+import { DbModule } from '../db/db.module';
 
 @Module({
-  imports: [ConfigModule, HttpModule, UtilsModule, RecipeModule],
+  imports: [
+    ConfigModule,
+    HttpModule,
+    UtilsModule,
+    RecipeModule,
+    AuthModule,
+    UserModule,
+    DbModule,
+  ],
   controllers: [OpenaiTestControllerController, RecommenderController],
   providers: [OpenaiService, RecommenderService],
 })

--- a/api/src/modules/recommender/services/recommender.service.ts
+++ b/api/src/modules/recommender/services/recommender.service.ts
@@ -3,12 +3,18 @@ import { OpenaiService } from './openai.service';
 import { OpenAIMeal } from '../types';
 import { RecipeInput } from '../../recipe/types';
 import { RecipeService } from '../../recipe/services/recipe.service';
+import { UserContextService } from '../../user/services/user-context.service';
+import { PrismaService } from '../../db/services/prisma.service';
+import { Logger } from 'nestjs-pino';
 
 @Injectable()
 export class RecommenderService {
   constructor(
     private readonly openaiService: OpenaiService,
     private readonly recipeService: RecipeService,
+    private readonly userContextService: UserContextService,
+    private readonly prismaService: PrismaService,
+    private readonly logger: Logger,
   ) {}
 
   public async requestRecipe(input: {
@@ -28,8 +34,26 @@ export class RecommenderService {
       })),
     };
 
-    await this.recipeService.saveRecipe(recipeInput);
+    this.logger.log('Saving recipe', {
+      recipeInput,
+    });
+    const savedRecipe = await this.recipeService.saveRecipe(recipeInput);
 
+    // Associate this recipe to the current user
+    const userId = await this.userContextService.userId;
+
+    this.logger.log('Associating recipe to user', {
+      userId,
+      recipeId: savedRecipe.id,
+    });
+    await this.prismaService.userRecipe.create({
+      data: {
+        userId,
+        recipeId: savedRecipe.id,
+      },
+    });
+
+    this.logger.log('Completed recipe lookup');
     return recipe;
   }
 }

--- a/api/src/modules/user/services/user-context.service.ts
+++ b/api/src/modules/user/services/user-context.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
+
+@Injectable()
+export class UserContextService {
+  constructor(@Inject(REQUEST) private request: Request) {}
+
+  public get userId(): number {
+    if (this.request['user'] === undefined) {
+      return 0;
+    }
+
+    const user = this.request.user as any;
+
+    return user.userId;
+  }
+}

--- a/api/src/modules/user/user.module.ts
+++ b/api/src/modules/user/user.module.ts
@@ -3,11 +3,12 @@ import { UserService } from './services/user.service';
 import { AuthModule } from '../auth/auth.module';
 import { DbModule } from '../db/db.module';
 import { UserController } from './controllers/user.controller';
+import { UserContextService } from './services/user-context.service';
 
 @Module({
   controllers: [UserController],
   imports: [AuthModule, DbModule],
-  providers: [UserService],
-  exports: [UserService],
+  providers: [UserService, UserContextService],
+  exports: [UserService, UserContextService],
 })
 export class UserModule {}


### PR DESCRIPTION
When a user request comes in, the `user.guard` decodes the JWT, putting the `userId` onto the `request`. Afterwards, if you call the `UserContextService`, it looks a the context of the current request and plucks the UserId off.

Right now this is being used to associate a user to a requested recipe.